### PR TITLE
Remake the library registry | Add vector util functions under "VecUtil"

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityScriptableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityScriptableRollingStock.java
@@ -325,8 +325,9 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
                      .addFunction("setNBTTag", (k, v) -> setNBTTag(k.tojstring(), v))
                      .addFunctionWithReturn("getNBTTag", (k) -> getNBTTag(k.tojstring()))
                      .addFunctionWithReturn("getStockPosition", () -> ScriptVectorUtil.constructVec3Table(this.getPosition()))
+                     .addFunctionWithReturn("getStockMatrix", () -> ScriptVectorUtil.constructMatrix4Table(this.getModelMatrix()))
                      .addFunctionWithReturn("newVector", (x, y, z) -> ScriptVectorUtil.constructVec3Table(x, y, z))
-                     .setAsLibrary(globals);
+                     .setInGlobals(globals);
 
             LuaLibrary.create("World")
                      .addFunctionWithReturn("isRainingAt", pos -> LuaValue.valueOf(getWorld().isRaining(ScriptVectorUtil.convertToVec3i(pos))))
@@ -335,7 +336,7 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
                      .addFunctionWithReturn("getBlockLightLevelAt", pos -> LuaValue.valueOf(getWorld().getBlockLightLevel(ScriptVectorUtil.convertToVec3i(pos))))
                      .addFunctionWithReturn("getSkyLightLevelAt", pos -> LuaValue.valueOf(getWorld().getSkyLightLevel(ScriptVectorUtil.convertToVec3i(pos))))
                      .addFunctionWithReturn("getTicks", () -> LuaValue.valueOf(getWorld().getTicks()))
-                     .setAsLibrary(globals);
+                     .setInGlobals(globals);
 
             LuaLibrary.create("Debug")
                      .addFunction("printToInfoLog", arg -> ModCore.info(arg.tojstring()))
@@ -346,8 +347,9 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
                              .filter(Entity::isPlayer)
                              .map(Entity::asPlayer)
                              .forEach(player -> player.sendMessage(PlayerMessage.direct(arg.tojstring()))))
-                     .setAsLibrary(globals);
+                     .setInGlobals(globals);
 
+            ScriptVectorUtil.VecUtil.setInGlobals(globals);
             LuaValue chunk = globals.load(luaScript);
             chunk.call();
 

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityScriptableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityScriptableRollingStock.java
@@ -10,13 +10,14 @@ import cam72cam.immersiverailroading.library.Permissions;
 import cam72cam.immersiverailroading.model.components.ModelComponent;
 import cam72cam.immersiverailroading.model.part.CustomParticleConfig;
 import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition;
+import cam72cam.immersiverailroading.script.LuaLibrary;
+import cam72cam.immersiverailroading.script.ScriptVectorUtil;
 import cam72cam.immersiverailroading.util.DataBlock;
 import cam72cam.mod.ModCore;
 import cam72cam.mod.entity.Entity;
 import cam72cam.mod.entity.Player;
 import cam72cam.mod.item.ClickResult;
 import cam72cam.mod.math.Vec3d;
-import cam72cam.mod.math.Vec3i;
 import cam72cam.mod.model.obj.OBJGroup;
 import cam72cam.mod.resource.Identifier;
 import cam72cam.mod.serialization.*;
@@ -32,7 +33,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import org.luaj.vm2.LuaFunction;
 public abstract class EntityScriptableRollingStock extends EntityCoupleableRollingStock implements ReadoutsEventHandler {
 
     private LuaValue tickEvent;
@@ -40,9 +40,6 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
     private boolean isSleeping;
     private long lastExecutionTime;
     private boolean wakeLuaScriptCalled = false;
-    LuaTable IRLibrary = new LuaTable();
-    LuaTable debugLibrary = new LuaTable();
-    LuaTable worldLibrary = new LuaTable();
     private final Map<String, InputStream> moduleMap = new HashMap<>();
     private final Map<String, String> componentTextMap = new HashMap<>();
     private final Map<Integer, ParticleState> particleStates = new HashMap<>();
@@ -108,7 +105,7 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
     @Override
     public void onTick() {
         super.onTick();
-        if (!getWorld().isServer) {
+        if (getWorld().isClient) {
             return;
         }
         if (getDefinition().script != null && !ConfigPerformance.disableLuaScript) {
@@ -263,15 +260,12 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
             safeOs.set("date", globals.get("os").get("date"));
             safeOs.set("clock", globals.get("os").get("clock"));
             safeOs.set("difftime", globals.get("os").get("difftime"));
-
-
             globals.set("os", safeOs);
 
             globals.set("io", LuaValue.NIL);
             globals.set("luajava", LuaValue.NIL);
             globals.set("coroutine", LuaValue.NIL);
             globals.set("debug", LuaValue.NIL);
-
 
             // Get Lua file from Json
             Identifier script = getDefinition().script;
@@ -300,11 +294,59 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
                 preloadModules(globals, moduleMap);
             }
 
-            setLuaFunctions();
+            LuaLibrary.create("IR")
+                     .addFunction("setCG", (control, val) -> setControlGroup(control.tojstring(), val.tofloat()))
+                     .addFunctionWithReturn("getCG", control -> LuaValue.valueOf(getControlGroup(control.tojstring())))
+                     .addFunction("setPaint", newTexture -> this.setNewTexture(newTexture.tojstring()))
+                     .addFunctionWithReturn("getPaint", () -> LuaValue.valueOf(this.getCurrentTexture()))
+                     .addFunctionWithReturn("getReadout", readout -> LuaValue.valueOf(getReadout(readout.tojstring())))
+                     .addFunction("setPerformance", this::setPerformance)
+                     .addFunctionWithReturn("getPerformance", this::getPerformance)
+                     .addFunction("couplerEngaged", this::setCouplerEngagedLua)
+                     .addFunction("setThrottle", this::setThrottleLua)
+                     .addFunctionWithReturn("getThrottle", this::getThrottleLua)
+                     .addFunction("setReverser", this::setReverserLua)
+                     .addFunctionWithReturn("getReverser", this::getReverserLua)
+                     .addFunction("setTrainBrake", this::setTrainBrakeLua)
+                     .addFunctionWithReturn("getTrainBrake", this::getTrainBrakeLua)
+                     .addFunction("setIndependentBrake", this::setIndependentBrakeLua)
+                     .addFunction("setSound", val -> {/*setNewSound(val)*/})
+                     .addFunction("setGlobal", (control, val) -> setGlobalControlGroup(control.tojstring(), val.tofloat()))
+                     .addFunction("setUnit", (control, val) -> setUnitControlGroup(control.tojstring(), val.tofloat()))
+                     .addFunction("setText", this::textFieldDef)
+                     .addFunction("setTag", val -> setEntityTag(val.tojstring()))
+                     .addFunctionWithReturn("getTag", () -> LuaValue.valueOf(getTag()))
+                     .addFunctionWithReturn("getTrain", this::getTrainConsist)
+                     .addFunction("setIndividualCG", this::setIndividualCG)
+                     .addFunctionWithReturn("getIndividualCG", this::getIndividualCG)
+                     .addFunctionWithReturn("isTurnedOn", () -> LuaValue.valueOf(getEngineState()))
+                     .addFunction("engineStartStop", this::setTurnedOnLua)
+                     .addFunction("newParticle", this::particleDefinition)
+                     .addFunction("setNBTTag", (k, v) -> setNBTTag(k.tojstring(), v))
+                     .addFunctionWithReturn("getNBTTag", (k) -> getNBTTag(k.tojstring()))
+                     .addFunctionWithReturn("getStockPosition", () -> ScriptVectorUtil.constructVec3Table(this.getPosition()))
+                     .addFunctionWithReturn("newVector", (x, y, z) -> ScriptVectorUtil.constructVec3Table(x, y, z))
+                     .setAsLibrary(globals);
 
-            globals.set("IR", IRLibrary);
-            globals.set("Debug", debugLibrary);
-            globals.set("World", worldLibrary);
+            LuaLibrary.create("World")
+                     .addFunctionWithReturn("isRainingAt", pos -> LuaValue.valueOf(getWorld().isRaining(ScriptVectorUtil.convertToVec3i(pos))))
+                     .addFunctionWithReturn("getTemperatureAt", pos -> LuaValue.valueOf(getWorld().getTemperature(ScriptVectorUtil.convertToVec3i(pos))))
+                     .addFunctionWithReturn("getSnowLevelAt", pos -> LuaValue.valueOf(getWorld().getSnowLevel(ScriptVectorUtil.convertToVec3i(pos))))
+                     .addFunctionWithReturn("getBlockLightLevelAt", pos -> LuaValue.valueOf(getWorld().getBlockLightLevel(ScriptVectorUtil.convertToVec3i(pos))))
+                     .addFunctionWithReturn("getSkyLightLevelAt", pos -> LuaValue.valueOf(getWorld().getSkyLightLevel(ScriptVectorUtil.convertToVec3i(pos))))
+                     .addFunctionWithReturn("getTicks", () -> LuaValue.valueOf(getWorld().getTicks()))
+                     .setAsLibrary(globals);
+
+            LuaLibrary.create("Debug")
+                     .addFunction("printToInfoLog", arg -> ModCore.info(arg.tojstring()))
+                     .addFunction("printToWarnLog", arg -> ModCore.warn(arg.tojstring()))
+                     .addFunction("printToErrorLog", arg -> ModCore.error(arg.tojstring()))
+                     .addFunction("printToPassengerDialog", arg ->
+                             getPassengers().stream()
+                             .filter(Entity::isPlayer)
+                             .map(Entity::asPlayer)
+                             .forEach(player -> player.sendMessage(PlayerMessage.direct(arg.tojstring()))))
+                     .setAsLibrary(globals);
 
             LuaValue chunk = globals.load(luaScript);
             chunk.call();
@@ -338,284 +380,6 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
                 ModCore.error("An error occurred while preloading lua modules", e);
             }
         }
-    }
-
-    public void setLuaFunctions() {
-        IRLibrary.set("getCG", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue control) {
-                float result = getControlGroup(control.tojstring());
-                return LuaValue.valueOf(result);
-            }
-        });
-        IRLibrary.set("setCG", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue control, LuaValue val) {
-                setControlGroup(control.tojstring(), val.tofloat());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("getPaint", new LuaFunction() {
-            @Override
-            public LuaValue call() {
-                String result = getCurrentTexture();
-                return LuaValue.valueOf(result);
-            }
-        });
-        IRLibrary.set("setPaint", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue newTexture) {
-                setNewTexture(newTexture.tojstring());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("getReadout", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue readout) {
-                float result = getReadout(readout.tojstring());
-                return LuaValue.valueOf(result);
-            }
-        });
-        IRLibrary.set("setPerformance", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue performanceType, LuaValue newVal) {
-                setPerformance(performanceType.tojstring(), newVal.todouble());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("couplerEngaged", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue position, LuaValue newState) {
-                setCouplerEngaged(position.tojstring(), newState.toboolean());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("setThrottle", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue val) {
-                setThrottleLua(val.tofloat());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("setReverser", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue val) {
-                setReverserLua(val.tofloat());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("setTrainBrake", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue val) {
-                setBrakeLua(val.tofloat());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("setIndependentBrake", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue val) {
-                setIndependentBrakeLua(val.tofloat());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("getThrottle", new LuaFunction() {
-            @Override
-            public LuaValue call() {
-                return LuaValue.valueOf(getThrottleLua());
-            }
-        });
-        IRLibrary.set("getReverser", new LuaFunction() {
-            @Override
-            public LuaValue call() {
-                return LuaValue.valueOf(getReverserLua());
-            }
-        });
-        IRLibrary.set("getTrainBrake", new LuaFunction() {
-            @Override
-            public LuaValue call() {
-                return LuaValue.valueOf(getTrainBrakeLua());
-            }
-        });
-        IRLibrary.set("setSound", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue val) {
-//                setNewSound(val);
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("setGlobal", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue control, LuaValue val) {
-                setGlobalControlGroup(control.tojstring(), val.tofloat());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("setUnit", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue control, LuaValue val) {
-                setUnitControlGroup(control.tojstring(), val.tofloat());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("setText", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue table) {
-                textFieldDef(table);
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("getTag", new LuaFunction() {
-            @Override
-            public LuaValue call() {
-                return LuaValue.valueOf(getTag());
-            }
-        });
-        IRLibrary.set("getTrain", new LuaFunction() {
-            @Override
-            public LuaValue call() {
-                return getTrainConsist();
-            }
-        });
-        IRLibrary.set("setIndividualCG", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue luaValue) {
-                setIndividualCG(luaValue);
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("getIndividualCG", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue luaValue) {
-                return getIndividualCG(luaValue);
-            }
-        });
-        IRLibrary.set("engineStartStop", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue luaValue) {
-                setTurnedOnLua(luaValue.toboolean());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("isTurnedOn", new LuaFunction() {
-            @Override
-            public LuaValue call() {
-                return LuaValue.valueOf(getEngineState());
-            }
-        });
-        IRLibrary.set("setTag", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue tag) {
-                setEntityTag(tag.tojstring());
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("newParticle", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue luaValue) {
-                particleDefinition(luaValue);
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("getPerformance", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue luaValue) {
-                return getPerformance(luaValue.tojstring());
-            }
-        });
-        IRLibrary.set("setNBTTag", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue key, LuaValue value) {
-                setNBTTag(key.tojstring(), value);
-                return LuaValue.NIL;
-            }
-        });
-        IRLibrary.set("getNBTTag", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue key) {
-                return getNBTTag(key.tojstring());
-            }
-        });
-        IRLibrary.set("getStockPosition", new LuaFunction() {
-            @Override
-            public LuaValue call() {
-                return constructVec3Table(getPosition());
-            }
-        });
-        IRLibrary.set("newVector", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue x, LuaValue y, LuaValue z) {
-                return constructVec3Table(new Vec3d(x.todouble(), y.todouble(), z.todouble()));
-            }
-        });
-
-        debugLibrary.set("printToInfoLog", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue msg) {
-                ModCore.info(msg.tojstring());
-                return LuaValue.NIL;
-            }
-        });
-        debugLibrary.set("printToWarnLog", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue msg) {
-                ModCore.warn(msg.tojstring());
-                return LuaValue.NIL;
-            }
-        });
-        debugLibrary.set("printToErrorLog", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue msg) {
-                ModCore.error(msg.tojstring());
-                return LuaValue.NIL;
-            }
-        });
-        debugLibrary.set("printToPassengerDialog", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue msg) {
-                getPassengers().stream()
-                        .filter(Entity::isPlayer)
-                        .map(Entity::asPlayer)
-                        .forEach(player -> player.sendMessage(PlayerMessage.direct(msg.tojstring())));
-                return LuaValue.NIL;
-            }
-        });
-
-        worldLibrary.set("isRainingAt", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue vector) {
-                return LuaValue.valueOf(getWorld().isRaining(convertToVec3i(vector)));
-            }
-        });
-        worldLibrary.set("getTemperatureAt", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue vector) {
-                return LuaValue.valueOf(getWorld().getTemperature(convertToVec3i(vector)));
-            }
-        });
-        worldLibrary.set("getSnowLevelAt", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue vector) {
-                return LuaValue.valueOf(getWorld().getSnowLevel(convertToVec3i(vector)));
-            }
-        });
-        worldLibrary.set("getBlockLightLevelAt", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue vector) {
-                return LuaValue.valueOf(getWorld().getBlockLightLevel(convertToVec3i(vector)));
-            }
-        });
-        worldLibrary.set("getSkyLightLevelAt", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue vector) {
-                return LuaValue.valueOf(getWorld().getSkyLightLevel(convertToVec3i(vector)));
-            }
-        });
-        worldLibrary.set("getTicks", new LuaFunction() {
-            @Override
-            public LuaValue call() {
-                return LuaValue.valueOf(getWorld().getTicks());
-            }
-        });
     }
 
     public float getControlGroup(String control) {
@@ -661,21 +425,25 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
         return readoutState.get(readout);
     }
 
-    protected void setPerformance(String performanceType, double val) {
-        switch (performanceType) {
-            case "max_speed_kmh":
-                getDefinition().setMaxSpeed(val);
-                break;
-            case "tractive_effort_lbf":
-                getDefinition().setTraction(val);
-                break;
-            case "horsepower":
-                getDefinition().setHorsepower(val);
-                break;
-        }
+    protected void setPerformance(LuaValue performanceType, LuaValue val) {
+        String type = performanceType.tojstring();
+        double newValue = val.todouble();
+//        switch (type) {
+//            case "max_speed_kmh":
+//                getDefinition().setMaxSpeed(newValue);
+//                break;
+//            case "tractive_effort_lbf":
+//                getDefinition().setTraction(newValue);
+//                break;
+//            case "horsepower":
+//                getDefinition().setHorsepower(newValue);
+//                break;
+//        }
     }
 
-    public void setCouplerEngaged(String position, Boolean engaged) {
+    public void setCouplerEngagedLua(LuaValue positionLua, LuaValue engagedLua) {
+        String position = positionLua.tojstring();
+        boolean engaged = engagedLua.toboolean();
         switch (position) {
             case "FRONT":
                 setCouplerEngaged(CouplerType.FRONT, engaged);
@@ -948,8 +716,9 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
         }
     }
 
-    protected LuaValue getPerformance(String type) {
-        switch (type) {
+    protected LuaValue getPerformance(LuaValue type) {
+        String strType = type.tojstring();
+        switch (strType) {
             case "max_speed_kmh":
                 return LuaValue.valueOf(getDefinition().getMaxSpeed());
             case "horsepower":
@@ -1182,32 +951,32 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
         }
     }
 
-    public void setThrottleLua(float val) {
+    public void setThrottleLua(LuaValue val) {
 
     }
 
-    public void setReverserLua(float val) {
+    public void setReverserLua(LuaValue val) {
 
     }
 
-    public void setBrakeLua(float val) {
+    public void setTrainBrakeLua(LuaValue val) {
 
     }
 
-    public void setIndependentBrakeLua(float val) {
+    public void setIndependentBrakeLua(LuaValue val) {
 
     }
 
-    public float getThrottleLua() {
-        return 0;
+    public LuaValue getThrottleLua() {
+        return LuaValue.valueOf(0);
     }
 
-    public float getReverserLua() {
-        return 0;
+    public LuaValue getReverserLua() {
+        return LuaValue.valueOf(0);
     }
 
-    public float getTrainBrakeLua() {
-        return 0;
+    public LuaValue getTrainBrakeLua() {
+        return LuaValue.valueOf(0);
     }
 
     @Override
@@ -1216,7 +985,7 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
         wakeLuaScriptCalled = true;
     }
 
-    public void setTurnedOnLua(boolean b) {
+    public void setTurnedOnLua(LuaValue b) {
     }
 
 
@@ -1387,48 +1156,6 @@ public abstract class EntityScriptableRollingStock extends EntityCoupleableRolli
             return ((Data) obj).toLuaValue();
         }
         return LuaValue.NIL;  // If the type doesn't match, return Lua NIL
-    }
-
-    private static LuaTable constructVec3Table(Vec3i vec3i){
-        return constructVec3Table(new Vec3d(vec3i.x, vec3i.y, vec3i.z));
-    }
-
-    private static LuaTable constructVec3Table(Vec3d vec3d){
-        LuaTable vector3d = new LuaTable();
-        vector3d.set("x", vec3d.x);
-        vector3d.set("y", vec3d.y);
-        vector3d.set("z", vec3d.z);
-        vector3d.set("add", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue arg) {
-                vector3d.set("x", vector3d.get("x").add(arg.get("x")));
-                vector3d.set("y", vector3d.get("y").add(arg.get("y")));
-                vector3d.set("z", vector3d.get("z").add(arg.get("z")));
-                return LuaValue.NIL;
-            }
-        });
-        vector3d.set("scale", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue arg) {
-                vector3d.set("x", vector3d.get("x").add(arg.get("x")));
-                vector3d.set("y", vector3d.get("y").add(arg.get("y")));
-                vector3d.set("z", vector3d.get("z").add(arg.get("z")));
-                return LuaValue.NIL;
-            }
-        });
-        vector3d.set("lengthSquared", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue arg) {
-                return vector3d.get("x").mul(vector3d.get("x")).add(
-                       vector3d.get("y").mul(vector3d.get("y")).add(
-                       vector3d.get("z").mul(vector3d.get("z"))));
-            }
-        });
-        return vector3d;
-    }
-
-    private static Vec3i convertToVec3i(LuaValue vector){
-        return new Vec3i(vector.get("x").toint(), vector.get("y").toint(), vector.get("z").toint());
     }
 
     private static class LuaDataMapper implements TagMapper<Map<String, Object>> {

--- a/src/main/java/cam72cam/immersiverailroading/entity/Locomotive.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/Locomotive.java
@@ -497,8 +497,8 @@ public abstract class Locomotive extends FreightTank{
 	}
 
 	@Override
-	public float getThrottleLua() {
-		return getThrottle();
+	public LuaValue getThrottleLua() {
+		return LuaValue.valueOf(getThrottle());
 	}
 
 	public float getThrottle() {
@@ -506,8 +506,8 @@ public abstract class Locomotive extends FreightTank{
 	}
 
 	@Override
-	public void setThrottleLua(float val) {
-		setThrottle(val);
+	public void setThrottleLua(LuaValue val) {
+		setThrottle(val.tofloat());
 //		ModCore.info("Original value: " + val);
 //		ModCore.info("Throttle_X: " + ModelComponentType.THROTTLE_X);
 	}
@@ -529,8 +529,8 @@ public abstract class Locomotive extends FreightTank{
 	}
 
 	@Override
-	public float getReverserLua() {
-		return getReverser();
+	public LuaValue getReverserLua() {
+		return LuaValue.valueOf(getReverser());
 	}
 
 	public float getReverser() {
@@ -538,8 +538,8 @@ public abstract class Locomotive extends FreightTank{
 	}
 
 	@Override
-	public void setReverserLua(float val) {
-		setReverser(val);
+	public void setReverserLua(LuaValue val) {
+		setReverser(val.tofloat());
 	}
 
 
@@ -603,8 +603,8 @@ public abstract class Locomotive extends FreightTank{
 	}
 
 	@Override
-	public float getTrainBrakeLua() {
-		return getTrainBrake();
+	public LuaValue getTrainBrakeLua() {
+		return LuaValue.valueOf(getTrainBrake());
 	}
 
 	@Deprecated
@@ -616,8 +616,8 @@ public abstract class Locomotive extends FreightTank{
 	}
 
 	@Override
-	public void setBrakeLua(float val) {
-		setTrainBrake(val);
+	public void setTrainBrakeLua(LuaValue val) {
+		setTrainBrake(val.tofloat());
 	}
 
 
@@ -643,8 +643,8 @@ public abstract class Locomotive extends FreightTank{
 	}
 
 	@Override
-	public void setIndependentBrakeLua(float val) {
-		setIndependentBrake(val);
+	public void setIndependentBrakeLua(LuaValue val) {
+		setIndependentBrake(val.tofloat());
 	}
 
 	@Override
@@ -693,8 +693,9 @@ public abstract class Locomotive extends FreightTank{
 	}
 
 	@Override
-	protected LuaValue getPerformance(String type) {
-		switch (type) {
+	protected LuaValue getPerformance(LuaValue type) {
+		String strType = type.tojstring();
+		switch (strType) {
 			case "max_speed_kmh":
 				return LuaValue.valueOf(this.localMaxSpeed == -1 ? getDefinition().getMaxSpeed() : this.localMaxSpeed);
 			case "horsepower":
@@ -707,16 +708,18 @@ public abstract class Locomotive extends FreightTank{
 	}
 
 	@Override
-	protected void setPerformance(String performanceType, double val) {
-		switch (performanceType) {
+	protected void setPerformance(LuaValue performanceType, LuaValue val) {
+		String type = performanceType.tojstring();
+		double newValue = val.todouble();
+		switch (type) {
 			case "max_speed_kmh":
-				this.localMaxSpeed = val;
+				this.localMaxSpeed = newValue;
 				break;
 			case "tractive_effort_lbf":
-				this.localTraction = val;
+				this.localTraction = newValue;
 				break;
 			case "horsepower":
-				this.localHorsepower = val;
+				this.localHorsepower = newValue;
 				break;
 		}
 	}

--- a/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveDiesel.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveDiesel.java
@@ -15,6 +15,7 @@ import cam72cam.mod.entity.sync.TagSync;
 import cam72cam.mod.fluid.Fluid;
 import cam72cam.mod.fluid.FluidStack;
 import cam72cam.mod.serialization.TagField;
+import org.luaj.vm2.LuaValue;
 
 import java.util.List;
 import java.util.OptionalDouble;
@@ -288,8 +289,8 @@ public class LocomotiveDiesel extends Locomotive {
 		}
 	}
 	@Override
-	public void setTurnedOnLua(boolean b) {
-		setTurnedOn(b);
+	public void setTurnedOnLua(LuaValue b) {
+		setTurnedOn(b.toboolean());
 	}
 
 	@Override

--- a/src/main/java/cam72cam/immersiverailroading/script/LuaLibrary.java
+++ b/src/main/java/cam72cam/immersiverailroading/script/LuaLibrary.java
@@ -1,0 +1,251 @@
+package cam72cam.immersiverailroading.script;
+
+import cam72cam.mod.ModCore;
+import org.luaj.vm2.Globals;
+import org.luaj.vm2.LuaFunction;
+import org.luaj.vm2.LuaTable;
+import org.luaj.vm2.LuaValue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.*;
+
+/**
+ * Helper class to construct LuaLibrary
+ */
+public class LuaLibrary {
+    private final HashMap<String, Object[]> functions;
+    private final String type;
+
+    private LuaLibrary(String typeName){
+        this.type = typeName;
+        this.functions = new HashMap<>();
+    }
+
+    /**
+     * A static factory method
+     * @param typeName Type of the object or namespace of the library
+     * @return The constructed LuaLibrary
+     */
+    public static LuaLibrary create(String typeName){
+        return new LuaLibrary(typeName);
+    }
+
+    /**
+     * Register a function which has no input and output
+     * @param name Name of the function
+     * @param function Functioning part
+     * @return The class itself
+     */
+    public LuaLibrary addFunction(String name, Runnable function){
+        Object[] func = functions.getOrDefault(name, new Object[4]);
+        if(func[0] != null){
+            ModCore.error(String.format("Invalid overload function registry detected within object %s, the latter one won't be registered!", name));
+            return this;
+        }
+        func[0] = function;
+        functions.put(name, func);
+        return this;
+    }
+
+    /**
+     * Register a single parameter consumer function, like setter
+     * @param name Name of the function
+     * @param consumer Functioning part
+     * @return The class itself
+     */
+    public LuaLibrary addFunction(String name, Consumer<LuaValue> consumer){
+        Object[] func = functions.getOrDefault(name, new Object[4]);
+        if(func[1] != null){
+            ModCore.error(String.format("Invalid overload function registry detected within object %s, the latter one won't be registered!", name));
+            return this;
+        }
+        func[1] = consumer;
+        functions.put(name, func);
+        return this;
+    }
+
+    /**
+     * Register a double parameter consumer function, like setter
+     * @param name Name of the function
+     * @param consumer Functioning part
+     * @return The class itself
+     */
+    public LuaLibrary addFunction(String name, BiConsumer<LuaValue, LuaValue> consumer){
+        Object[] func = functions.getOrDefault(name, new Object[4]);
+        if(func[2] != null){
+            ModCore.error(String.format("Invalid overload function registry detected within object %s, the latter one won't be registered!", name));
+            return this;
+        }
+        func[2] = consumer;
+        functions.put(name, func);
+        return this;
+    }
+
+    /**
+     * Register a Triple parameter consumer function, like setter
+     * @param name Name of the function
+     * @param consumer Functioning part
+     * @return The class itself
+     */
+    public LuaLibrary addFunction(String name, TriConsumer<LuaValue, LuaValue, LuaValue> consumer){
+        Object[] func = functions.getOrDefault(name, new Object[4]);
+        if(func[3] != null){
+            ModCore.error(String.format("Invalid overload function registry detected within object %s, the latter one won't be registered!", name));
+            return this;
+        }
+        func[3] = consumer;
+        functions.put(name, func);
+        return this;
+    }
+
+    /**
+     * Register a zero parameter function with a return value, like getter
+     * @param name Name of the function
+     * @param supplier Functioning part
+     * @return The class itself
+     */
+    public LuaLibrary addFunctionWithReturn(String name, Supplier<LuaValue> supplier){
+        Object[] func = functions.getOrDefault(name, new Object[4]);
+        if(func[0] != null){
+            ModCore.error(String.format("Invalid overload function registry detected within object %s, the latter one won't be registered!", name));
+            return this;
+        }
+        func[0] = supplier;
+        functions.put(name, func);
+        return this;
+    }
+
+    /**
+     * Register a single parameter function with a return value
+     * @param name Name of the function
+     * @param function Functioning part
+     * @return The class itself
+     */
+    public LuaLibrary addFunctionWithReturn(String name, Function<LuaValue, LuaValue> function){
+        Object[] func = functions.getOrDefault(name, new Object[4]);
+        if(func[1] != null){
+            ModCore.error(String.format("Invalid overload function registry detected within object %s, the latter one won't be registered!", name));
+            return this;
+        }
+        func[1] = function;
+        functions.put(name, func);
+        return this;
+    }
+
+    /**
+     * Register a double parameter function with a return value
+     * @param name Name of the function
+     * @param function Functioning part
+     * @return The class itself
+     */
+    public LuaLibrary addFunctionWithReturn(String name, BiFunction<LuaValue, LuaValue, LuaValue> function){
+        Object[] func = functions.getOrDefault(name, new Object[4]);
+        if(func[2] != null){
+            ModCore.error(String.format("Invalid overload function registry detected within object %s, the latter one won't be registered!", name));
+            return this;
+        }
+        func[2] = function;
+        functions.put(name, func);
+        return this;
+    }
+
+    /**
+     * Register a triple parameter function with a return value
+     * @param name Name of the function
+     * @param function Functioning part
+     * @return The class itself
+     */
+    public LuaLibrary addFunctionWithReturn(String name, TriFunction<LuaValue, LuaValue, LuaValue, LuaValue> function){
+        Object[] func = functions.getOrDefault(name, new Object[4]);
+        if(func[3] != null){
+            ModCore.error(String.format("Invalid overload function registry detected within object %s, the latter one won't be registered!", name));
+            return this;
+        }
+        func[3] = function;
+        functions.put(name, func);
+        return this;
+    }
+
+    /**
+     * A terminal function to set up this object as library in the given globals
+     * @param globals The environment
+     */
+    public void setAsLibrary(Globals globals){
+        globals.set(this.type, initFunctions(new LuaTable()));
+    }
+
+    /**
+     * Internal function to set up functions
+     */
+    @SuppressWarnings("All")
+    private LuaTable initFunctions(LuaTable object){
+        for(Map.Entry<String, Object[]> func : functions.entrySet()){
+            object.set(func.getKey(), new LuaFunction() {
+                @Override
+                public LuaValue call() {
+                    if(func.getValue()[0] instanceof Runnable){
+                        ((Runnable)func.getValue()[0]).run();
+                        return NIL;
+                    } else {
+                        return ((Supplier<LuaValue>) func.getValue()[0]).get();
+                    }
+                }
+
+                @Override
+                public LuaValue call(LuaValue arg) {
+                    if(func.getValue()[1] instanceof Consumer){
+                        ((Consumer<LuaValue>)func.getValue()[1]).accept(arg);
+                        return NIL;
+                    } else {
+                        return ((Function<LuaValue, LuaValue>) func.getValue()[1]).apply(arg);
+                    }
+                }
+
+                @Override
+                public LuaValue call(LuaValue arg1, LuaValue arg2) {
+                    if(func.getValue()[2] instanceof BiConsumer){
+                        ((BiConsumer<LuaValue, LuaValue>)func.getValue()[2]).accept(arg1, arg2);
+                        return NIL;
+                    } else {
+                        return ((BiFunction<LuaValue, LuaValue, LuaValue>) func.getValue()[2]).apply(arg1, arg2);
+                    }
+                }
+
+                @Override
+                public LuaValue call(LuaValue arg1, LuaValue arg2, LuaValue arg3) {
+                    if(func.getValue()[3] instanceof TriConsumer){
+                        ((TriConsumer<LuaValue, LuaValue, LuaValue>)func.getValue()[3]).accept(arg1, arg2, arg3);
+                        return NIL;
+                    } else {
+                        return ((TriFunction<LuaValue, LuaValue, LuaValue, LuaValue>) func.getValue()[3]).apply(arg1, arg2, arg3);
+                    }
+                }
+            });
+        }
+        return object;
+    }
+
+    /**
+     * A consumer which consumes three parameters
+     * @param <I> Parameter No.1's type
+     * @param <J> Parameter No.2's type
+     * @param <K> Parameter No.3's type
+     */
+    @FunctionalInterface
+    public interface TriConsumer<I,J,K> {
+        void accept(I arg1, J arg2, K arg3);
+    }
+
+    /**
+     * A function which turns three parameters into one return value
+     * @param <I> Parameter No.1's type
+     * @param <J> Parameter No.2's type
+     * @param <K> Parameter No.3's type
+     * @param <R> Return value's type
+     */
+    @FunctionalInterface
+    public interface TriFunction<I,J,K,R> {
+        R apply(I arg1, J arg2, K arg3);
+    }
+}

--- a/src/main/java/cam72cam/immersiverailroading/script/LuaLibrary.java
+++ b/src/main/java/cam72cam/immersiverailroading/script/LuaLibrary.java
@@ -171,7 +171,7 @@ public class LuaLibrary {
      * A terminal function to set up this object as library in the given globals
      * @param globals The environment
      */
-    public void setAsLibrary(Globals globals){
+    public void setInGlobals(Globals globals){
         globals.set(this.type, initFunctions(new LuaTable()));
     }
 

--- a/src/main/java/cam72cam/immersiverailroading/script/ScriptVectorUtil.java
+++ b/src/main/java/cam72cam/immersiverailroading/script/ScriptVectorUtil.java
@@ -1,0 +1,59 @@
+package cam72cam.immersiverailroading.script;
+
+import cam72cam.mod.math.Vec3d;
+import cam72cam.mod.math.Vec3i;
+import org.luaj.vm2.LuaFunction;
+import org.luaj.vm2.LuaTable;
+import org.luaj.vm2.LuaValue;
+
+public class ScriptVectorUtil {
+    public static LuaTable constructVec3Table(Vec3i vec3i){
+        return constructVec3Table(vec3i.x, vec3i.y, vec3i.z);
+    }
+
+    public static LuaTable constructVec3Table(Vec3d vec3d){
+        return constructVec3Table(vec3d.x, vec3d.y, vec3d.z);
+    }
+
+    public static LuaTable constructVec3Table(LuaValue x, LuaValue y, LuaValue z){
+        return constructVec3Table(x.todouble(), y.todouble(), z.todouble());
+    }
+
+    public static LuaTable constructVec3Table(double x, double y, double z){
+        LuaTable vector3d = new LuaTable();
+        vector3d.set("x", x);
+        vector3d.set("y", y);
+        vector3d.set("z", z);
+        vector3d.set("add", new LuaFunction() {
+            @Override
+            public LuaValue call(LuaValue arg) {
+                vector3d.set("x", vector3d.get("x").add(arg.get("x")));
+                vector3d.set("y", vector3d.get("y").add(arg.get("y")));
+                vector3d.set("z", vector3d.get("z").add(arg.get("z")));
+                return LuaValue.NIL;
+            }
+        });
+        vector3d.set("scale", new LuaFunction() {
+            @Override
+            public LuaValue call(LuaValue arg) {
+                vector3d.set("x", vector3d.get("x").add(arg.get("x")));
+                vector3d.set("y", vector3d.get("y").add(arg.get("y")));
+                vector3d.set("z", vector3d.get("z").add(arg.get("z")));
+                return LuaValue.NIL;
+            }
+        });
+        vector3d.set("lengthSquared", new LuaFunction() {
+            @Override
+            public LuaValue call(LuaValue arg) {
+                return vector3d.get("x").mul(vector3d.get("x")).add(
+                        vector3d.get("y").mul(vector3d.get("y")).add(
+                                vector3d.get("z").mul(vector3d.get("z"))));
+            }
+        });
+        return vector3d;
+    }
+
+    public static Vec3i convertToVec3i(LuaValue vector){
+        return new Vec3i(vector.get("x").toint(), vector.get("y").toint(), vector.get("z").toint());
+    }
+}

--- a/src/main/java/cam72cam/immersiverailroading/script/ScriptVectorUtil.java
+++ b/src/main/java/cam72cam/immersiverailroading/script/ScriptVectorUtil.java
@@ -2,11 +2,40 @@ package cam72cam.immersiverailroading.script;
 
 import cam72cam.mod.math.Vec3d;
 import cam72cam.mod.math.Vec3i;
-import org.luaj.vm2.LuaFunction;
 import org.luaj.vm2.LuaTable;
 import org.luaj.vm2.LuaValue;
+import util.Matrix4;
 
 public class ScriptVectorUtil {
+    public static LuaLibrary VecUtil = LuaLibrary.create("VecUtil")
+            .addFunction("add", (vec1, vec2) -> {
+                vec1.set("x", vec1.get("x").add(vec2.get("x")));
+                vec1.set("y", vec1.get("y").add(vec2.get("y")));
+                vec1.set("z", vec1.get("z").add(vec2.get("z")));
+            })
+            .addFunction("scale", (vec, mul) -> {
+                vec.set("x", vec.get("x").mul(mul));
+                vec.set("y", vec.get("y").mul(mul));
+                vec.set("z", vec.get("z").mul(mul));
+            })
+            .addFunctionWithReturn("length", vec -> {
+                double x = vec.get("x").todouble();
+                double y = vec.get("y").todouble();
+                double z = vec.get("z").todouble();
+                return LuaValue.valueOf(Math.sqrt(x * x + y * y + z * z));
+            })
+            .addFunctionWithReturn("lengthSquared", vec -> {
+                double x = vec.get("x").todouble();
+                double y = vec.get("y").todouble();
+                double z = vec.get("z").todouble();
+                return LuaValue.valueOf(x * x + y * y + z * z);
+            })
+            .addFunctionWithReturn("applyMatrix", (matrix, vector) -> {
+                Matrix4 matrix4 = convertToMatrix4((LuaTable) matrix);
+                Vec3d vec3d = convertToVec3d(vector);
+                return constructVec3Table(matrix4.apply(vec3d));
+            });
+
     public static LuaTable constructVec3Table(Vec3i vec3i){
         return constructVec3Table(vec3i.x, vec3i.y, vec3i.z);
     }
@@ -24,36 +53,42 @@ public class ScriptVectorUtil {
         vector3d.set("x", x);
         vector3d.set("y", y);
         vector3d.set("z", z);
-        vector3d.set("add", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue arg) {
-                vector3d.set("x", vector3d.get("x").add(arg.get("x")));
-                vector3d.set("y", vector3d.get("y").add(arg.get("y")));
-                vector3d.set("z", vector3d.get("z").add(arg.get("z")));
-                return LuaValue.NIL;
-            }
-        });
-        vector3d.set("scale", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue arg) {
-                vector3d.set("x", vector3d.get("x").add(arg.get("x")));
-                vector3d.set("y", vector3d.get("y").add(arg.get("y")));
-                vector3d.set("z", vector3d.get("z").add(arg.get("z")));
-                return LuaValue.NIL;
-            }
-        });
-        vector3d.set("lengthSquared", new LuaFunction() {
-            @Override
-            public LuaValue call(LuaValue arg) {
-                return vector3d.get("x").mul(vector3d.get("x")).add(
-                        vector3d.get("y").mul(vector3d.get("y")).add(
-                                vector3d.get("z").mul(vector3d.get("z"))));
-            }
-        });
         return vector3d;
+    }
+
+    public static LuaTable constructMatrix4Table(Matrix4 matrix4){
+        LuaTable matrix = new LuaTable();
+        matrix.set("m00", matrix4.m00);
+        matrix.set("m01", matrix4.m01);
+        matrix.set("m02", matrix4.m02);
+        matrix.set("m03", matrix4.m03);
+        matrix.set("m10", matrix4.m10);
+        matrix.set("m11", matrix4.m11);
+        matrix.set("m12", matrix4.m12);
+        matrix.set("m13", matrix4.m13);
+        matrix.set("m20", matrix4.m20);
+        matrix.set("m21", matrix4.m21);
+        matrix.set("m22", matrix4.m22);
+        matrix.set("m23", matrix4.m23);
+        matrix.set("m30", matrix4.m30);
+        matrix.set("m31", matrix4.m31);
+        matrix.set("m32", matrix4.m32);
+        matrix.set("m33", matrix4.m33);
+        return matrix;
     }
 
     public static Vec3i convertToVec3i(LuaValue vector){
         return new Vec3i(vector.get("x").toint(), vector.get("y").toint(), vector.get("z").toint());
+    }
+
+    public static Vec3d convertToVec3d(LuaValue vector){
+        return new Vec3d(vector.get("x").todouble(), vector.get("y").todouble(), vector.get("z").todouble());
+    }
+
+    public static Matrix4 convertToMatrix4(LuaTable matrix){
+        return new Matrix4(matrix.get("m00").todouble(), matrix.get("m01").todouble(), matrix.get("m02").todouble(), matrix.get("m03").todouble(),
+                matrix.get("m10").todouble(), matrix.get("m11").todouble(), matrix.get("m12").todouble(), matrix.get("m13").todouble(),
+                matrix.get("m20").todouble(), matrix.get("m21").todouble(), matrix.get("m22").todouble(), matrix.get("m23").todouble(),
+                matrix.get("m30").todouble(), matrix.get("m31").todouble(), matrix.get("m32").todouble(), matrix.get("m33").todouble());
     }
 }


### PR DESCRIPTION
1. Add LuaLibrary class to simplify the library registry by using lambda expressions
2. Add ScriptVectorUtil to split code from EntityScriptableRollingStock 
3. Reconstruct Lua vector and matrix code, now functions like `add` are moved to `VecUtil`